### PR TITLE
travel statistics #181414773

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.8.4",
     "@babel/runtime": "^7.17.8",
+    "@joi/date": "^2.1.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/src/controllers/tripStatistics.js
+++ b/src/controllers/tripStatistics.js
@@ -1,0 +1,66 @@
+import { countTrips } from '../services/tripService';
+import successResponse from '../utils/successResponse';
+
+export const tripStatistics = async (req, res) => {
+  const userId = req.user.id;
+  const { start } = req.query;
+  let { end } = req.query;
+  const endingDate = end;
+  const isToday =
+    new Date(end).toLocaleDateString() === new Date().toLocaleDateString();
+  if (isToday) {
+    end = new Date();
+  } else {
+    end = new Date(end);
+    end.setDate(end.getDate() + 1);
+  }
+
+  const userRole = req.roleId;
+  if (userRole !== 1 && userRole !== 2) {
+    return res
+      .status(403)
+      .json('Statistics of travel are available for requester and Manager');
+  }
+  const trips = await countTrips(userId, start, end, userRole);
+  console.log('trips', trips);
+  if (trips.count !== undefined) {
+    return successResponse(res, 200, {
+      status: `You succesfully got all trips you have made between ${start} and ${endingDate} succesfully`,
+      trips: trips.count,
+    });
+  }
+  return res.status(500).json(`${trips.error}`);
+};
+export const recentTripStatistic = async (req, res) => {
+  const userId = req.user.id;
+  let { period } = req.query;
+  const { number } = req.query;
+  period = period.toLowerCase();
+  const end = new Date();
+  const start = new Date();
+  if (period === 'week' || period === 'weeks') {
+    start.setDate(start.getDate() - 7 * number);
+  } else if (period === 'day' || period === 'days') {
+    start.setDate(start.getDate() - number);
+  } else if (period === 'month' || period === 'months') {
+    start.setMonth(start.getMonth() - number);
+  } else if (period === 'year' || period === 'years') {
+    start.setYear(start.getYear() - number);
+  } else {
+    return res.status(401).json('Put valid period');
+  }
+  const userRole = await req.roleId;
+  if (userRole !== 1 && userRole !== 2) {
+    return res
+      .status(403)
+      .json('Statistics of travel are available for requester and Manager');
+  }
+  const trips = await countTrips(userId, start, end, userRole);
+  if (trips.count !== undefined) {
+    return successResponse(res, 200, {
+      status: `You succesfully got all trips you made ${number} ${period} ago`,
+      trips: trips.count,
+    });
+  }
+  return res.status(500).json(`${trips.error}`);
+};

--- a/src/middlewares/queryValidate.js
+++ b/src/middlewares/queryValidate.js
@@ -1,0 +1,15 @@
+export default function queryValidate(schema) {
+  return (req, res, next) => {
+    const { error } = schema.validate(req.query);
+    if (error) {
+      return res.status(400).send({
+        status: 400,
+        data: {
+          message: error.details[0].message.replace(/[/"]+/g, ''),
+          error,
+        },
+      });
+    }
+    next();
+  };
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ import locationsRoutes from './location';
 import accommodationRoutes from './accommodation';
 import roomsRoutes from './rooms';
 import triprequest from './tripRequestRoute';
+import tripStatistics from './tripStats';
 import multiCity from './multiCity';
 import approveOrRejectRequest from './approveOrRejectRequest';
 import chatRoutes from './chats';
@@ -24,6 +25,7 @@ router.use('/accommodations', accommodationRoutes);
 router.use('/rooms', roomsRoutes);
 router.use('/trip', triprequest);
 router.use('/trip', multiCity);
+router.use('/trip', tripStatistics);
 router.use('/trip', approveOrRejectRequest);
 router.use('/chats', chatRoutes);
 

--- a/src/routes/tripStats.js
+++ b/src/routes/tripStats.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import {
+  tripStatistics,
+  recentTripStatistic,
+} from '../controllers/tripStatistics';
+import verifyAuth from '../middlewares/auth';
+import { staticsValidate, periodValidate } from '../validations/tripValidation';
+import queryValidate from '../middlewares/queryValidate';
+
+const router = express.Router();
+
+router.get(
+  '/statistics',
+  queryValidate(staticsValidate),
+  verifyAuth,
+  tripStatistics
+);
+router.get(
+  '/statistics/recent',
+  queryValidate(periodValidate),
+  verifyAuth,
+  recentTripStatistic
+);
+
+export default router;

--- a/src/services/tripService.js
+++ b/src/services/tripService.js
@@ -1,0 +1,43 @@
+/* eslint-disable import/prefer-default-export */
+import { Op } from 'sequelize';
+import models from '../database/models';
+
+const { TripRequest, Accommodation, Users } = models;
+
+export const countTrips = async (userId, start, end, userRole) => {
+  try {
+    if (userRole === 1) {
+      const trips = await TripRequest.findAndCountAll({
+        where: {
+          [Op.and]: [
+            { requesterId: userId },
+            { createdAt: { [Op.between]: [start, end] } },
+            { status: 'approved' },
+          ],
+        },
+      });
+      return trips;
+    }
+    if (userRole === 2) {
+      const accomodation = await models.Accommodation.findAll({
+        where: { managerId: userId },
+      });
+      const ids = accomodation.map((accom) => accom.id);
+      if (!ids.length) {
+        return { count: 0 };
+      }
+      const trips = await TripRequest.findAndCountAll({
+        where: {
+          accomodationId: {
+            [Op.or]: ids,
+          },
+          createdAt: { [Op.between]: [start, end] },
+          status: 'approved',
+        },
+      });
+      return trips;
+    }
+  } catch (error) {
+    return { error };
+  }
+};

--- a/src/swagger/trip.doc.js
+++ b/src/swagger/trip.doc.js
@@ -400,6 +400,98 @@ const tripPath = {
       },
     },
   },
+
+  '/api/trip/statistics?start={start}&end={end}': {
+    get: {
+      tags: ['Trip Statistics'],
+      description: 'Get trip request',
+      summary: 'Get number of trips made during a range of period',
+      parameters: [
+        {
+          name: 'start',
+          in: 'path',
+          required: true,
+          description: 'starting date',
+        },
+        {
+          name: 'end',
+          in: 'path',
+          required: true,
+          description: 'ending date',
+        },
+      ],
+
+      security: [
+        {
+          bearerAuth: [],
+        },
+      ],
+
+      responses: {
+        200: {
+          description: 'Trip Requests Retrivied successfully',
+        },
+        400: {
+          description: 'Validation Error',
+        },
+        401: {
+          description: 'Invalid credentials',
+        },
+        404: {
+          description: 'Requests not Found',
+        },
+        500: {
+          description: 'Internal Server Error',
+        },
+      },
+    },
+  },
+
+  '/api/trip/statistics/recent?period={period}&number={number}': {
+    get: {
+      tags: ['Trip Statistics'],
+      description: 'Get trip request',
+      summary: 'Get number of trips made during a range of period',
+      parameters: [
+        {
+          name: 'period',
+          in: 'path',
+          required: true,
+          description: 'type of period like Day, Week, Month and  Year',
+        },
+        {
+          name: 'number',
+          in: 'path',
+          required: true,
+          description: 'number of period',
+        },
+      ],
+
+      security: [
+        {
+          bearerAuth: [],
+        },
+      ],
+
+      responses: {
+        200: {
+          description: 'Trip Requests Retrivied successfully',
+        },
+        400: {
+          description: 'Validation Error',
+        },
+        401: {
+          description: 'Invalid credentials',
+        },
+        404: {
+          description: 'Requests not Found',
+        },
+        500: {
+          description: 'Internal Server Error',
+        },
+      },
+    },
+  },
 };
 
 export default tripPath;

--- a/src/validations/tripValidation.js
+++ b/src/validations/tripValidation.js
@@ -1,0 +1,33 @@
+import DateExtension from '@joi/date';
+import * as JoiImport from 'joi';
+
+const Joi = JoiImport.extend(DateExtension);
+
+const staticsValidate = Joi.object().keys({
+  start: Joi.date()
+    .utc('javascript')
+    .max('now')
+    .label('Starting date')
+    .messages({
+      'date.max': 'starting date must be less than or equal to today',
+    }),
+  end: Joi.date()
+    .utc('javascript')
+    .min(Joi.ref('start'))
+    .max('now')
+    .label('Ending date')
+    .messages({
+      'date.min': `The ending date must be greater than starting date`,
+      'date.max': 'ending date must be less than or equal to today',
+    }),
+});
+const periodValidate = Joi.object().keys({
+  period: Joi.string()
+    .required()
+    .label('Period must be valid. Day,Week,Month,Year'),
+
+  number: Joi.number()
+    .min(1)
+    .label('Number of periods must be a positive integer'),
+});
+export { staticsValidate, periodValidate };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,6 +1133,13 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@joi/date@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@joi/date/-/date-2.1.0.tgz#fa7e3069a63c17d9ebe51a0b667f090c288de237"
+  integrity sha512-2zN5m0LgxZp/cynHGbzEImVmFIa+n+IOb/Nlw5LX/PLJneeCwG1NbiGw7MvPjsAKUGQK8z31Nn6V6lEN+4fZhg==
+  dependencies:
+    moment "2.x.x"
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
@@ -5689,6 +5696,11 @@ moment-timezone@^0.5.34:
   integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
   dependencies:
     moment ">= 2.9.0"
+
+moment@2.x.x:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
 
 "moment@>= 2.9.0", moment@^2.29.1:
   version "2.29.1"


### PR DESCRIPTION
## 1. Name of task
Users should get stats of trips made in the last X timeframe
## 2. Pivot Tracker ID
https://www.pivotaltracker.com/story/show/181414773
## 3. Branch Name
ft-travel-statistics-181414618
## 4. Description of task
Why
As an authenticated user, I should get the stats in terms of number of trips made in the last months, days, weeks etc.
Managers and travelers should get detailed statistics of the number of trips he/she has made in the recent past

## 7. Logic on the task to be completed
-The user should provide the period that he/she wants the trips he has made and the system should calculate the approved trips in the range provided by the user and the is of the user
-Manager should also provide the period of time that he/she wants the trips that he has managed the the system should calculate the trips in that range.

## 8. Logic On Actual Implementation
This was implemented by creating two GET end points. The first one is about get the statistics of trips made in specific time range by the user or manager and the second one is about getting the trips made in x time back.

## 9. How can this be manually tested
-Swagger: After reaching swagger doc You first login as requester or as manager Then you go under the trip tag on the GET end point of statistics . There are two endpoints the first one you put in the box the time range that you want the trips statistics then you execute (N.B the date must be valid and less than today's date and the end date must be greater than starting date). The second you put the period which can be day, week, month or year(you can but them in plural and it is case insensitive).then you put the number of period. Both end point if successfully give out 200 status code or 404 if not or 500 for server error.